### PR TITLE
[BISON-19] Add impersonation functionality for users and update permissions

### DIFF
--- a/app/Filament/Pages/ManageSettings.php
+++ b/app/Filament/Pages/ManageSettings.php
@@ -22,7 +22,7 @@ class ManageSettings extends SettingsPage
 
     protected static string|UnitEnum|null $navigationGroup = NavigationGroupsEnum::ADMIN;
 
-    protected static string|BackedEnum|null $navigationIcon = 'phosphor-gear-six';
+    protected static string|BackedEnum|null $navigationIcon = 'phosphor-sliders';
 
     public function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/Users/Pages/EditUser.php
+++ b/app/Filament/Resources/Users/Pages/EditUser.php
@@ -3,8 +3,10 @@
 namespace App\Filament\Resources\Users\Pages;
 
 use App\Filament\Resources\Users\UserResource;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use STS\FilamentImpersonate\Actions\Impersonate;
 
 class EditUser extends EditRecord
 {
@@ -13,7 +15,18 @@ class EditUser extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            DeleteAction::make(),
+            ActionGroup::make([
+                DeleteAction::make(),
+                Impersonate::make()
+                    ->record($this->getRecord())
+                    ->label(__('Impersonate User'))
+                    ->icon('phosphor-detective')
+                    ->redirectTo(route('filament.dashboard.pages.dashboard'))
+                    ->color('gray'),
+            ])
+                ->button()
+                ->label(__('Actions'))
+                ->color('gray'),
         ];
     }
 }

--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -19,7 +19,7 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static string|BackedEnum|null $navigationIcon = 'phosphor-users-duotone';
+    protected static string|BackedEnum|null $navigationIcon = 'phosphor-users';
 
     protected static string|UnitEnum|null $navigationGroup = NavigationGroupsEnum::ADMIN;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -87,7 +87,7 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         $name = str(Filament::getNameForDefaultAvatar($this))
             ->trim()
             ->explode(' ')
-            ->map(fn(string $segment): string => filled($segment) ? mb_substr($segment, 0, 1) : '')
+            ->map(fn (string $segment): string => filled($segment) ? mb_substr($segment, 0, 1) : '')
             ->join(' ');
 
         return uri('https://ui-avatars.com/api/')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+use App\Enums\RolesEnum;
 use App\Observers\UserObserver;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
 use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
@@ -65,12 +67,27 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         return true;
     }
 
+    public function canImpersonate(): bool
+    {
+        if ($this->hasRole(RolesEnum::SUPER_ADMIN)) {
+            return true;
+        }
+
+        return $this->can('admin.users.impersonate');
+    }
+
+    public function canBeImpersonated()
+    {
+        // Let's prevent Super Admins from being impersonated
+        return ! $this->hasRole(RolesEnum::SUPER_ADMIN);
+    }
+
     public function getFilamentAvatarUrl(): ?string
     {
         $name = str(Filament::getNameForDefaultAvatar($this))
             ->trim()
             ->explode(' ')
-            ->map(fn (string $segment): string => filled($segment) ? mb_substr($segment, 0, 1) : '')
+            ->map(fn(string $segment): string => filled($segment) ? mb_substr($segment, 0, 1) : '')
             ->join(' ');
 
         return uri('https://ui-avatars.com/api/')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -76,7 +76,7 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         return $this->can('admin.users.impersonate');
     }
 
-    public function canBeImpersonated()
+    public function canBeImpersonated(): bool
     {
         // Let's prevent Super Admins from being impersonated
         return ! $this->hasRole(RolesEnum::SUPER_ADMIN);

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laravel/framework": "^12",
         "laravel/tinker": "^2.9",
         "spatie/laravel-permission": "^6.10",
+        "stechstudio/filament-impersonate": "^4.0",
         "symfony/http-client": "^7.3",
         "symfony/mailgun-mailer": "^7.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5c844961ea90b1fa6b765b4468e7bfb",
+    "content-hash": "77e6c447e0609e8684de93d371c747b0",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -2198,6 +2198,73 @@
                 "source": "https://github.com/kirschbaum-development/eloquent-power-joins/tree/4.2.8"
             },
             "time": "2025-08-14T18:43:05+00:00"
+        },
+        {
+            "name": "lab404/laravel-impersonate",
+            "version": "1.7.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/404labfr/laravel-impersonate.git",
+                "reference": "5033f3433a55ca8bb2cc3e4a018a39dd8a327a9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/404labfr/laravel-impersonate/zipball/5033f3433a55ca8bb2cc3e4a018a39dd8a327a9f",
+                "reference": "5033f3433a55ca8bb2cc3e4a018a39dd8a327a9f",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+                "php": "^7.2 | ^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench": "^4.0 | ^5.0 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
+                "phpunit/phpunit": "^7.5 | ^8.0 | ^9.0 | ^10.0 | ^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Lab404\\Impersonate\\ImpersonateServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Lab404\\Impersonate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marceau Casals",
+                    "email": "marceau@casals.fr"
+                }
+            ],
+            "description": "Laravel Impersonate is a plugin that allows to you to authenticate as your users.",
+            "keywords": [
+                "auth",
+                "impersonate",
+                "impersonation",
+                "laravel",
+                "laravel-package",
+                "laravel-plugin",
+                "package",
+                "plugin",
+                "user"
+            ],
+            "support": {
+                "issues": "https://github.com/404labfr/laravel-impersonate/issues",
+                "source": "https://github.com/404labfr/laravel-impersonate/tree/1.7.7"
+            },
+            "time": "2025-02-24T16:18:38+00:00"
         },
         {
             "name": "laravel/framework",
@@ -5814,6 +5881,48 @@
                 }
             ],
             "time": "2025-01-13T13:04:43+00:00"
+        },
+        {
+            "name": "stechstudio/filament-impersonate",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stechstudio/filament-impersonate.git",
+                "reference": "4467c97308210f1a2c7bd8c4511bc6f976dd16e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stechstudio/filament-impersonate/zipball/4467c97308210f1a2c7bd8c4511bc6f976dd16e9",
+                "reference": "4467c97308210f1a2c7bd8c4511bc6f976dd16e9",
+                "shasum": ""
+            },
+            "require": {
+                "filament/filament": "^4.0",
+                "lab404/laravel-impersonate": "^1.7"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "STS\\FilamentImpersonate\\FilamentImpersonateServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "STS\\FilamentImpersonate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A Filament package to impersonate your users.",
+            "support": {
+                "issues": "https://github.com/stechstudio/filament-impersonate/issues",
+                "source": "https://github.com/stechstudio/filament-impersonate/tree/4.0.1"
+            },
+            "time": "2025-08-13T20:47:08+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/roles_permissions.php
+++ b/config/roles_permissions.php
@@ -23,6 +23,7 @@ return [
         'admin.users.delete',
         'admin.users.restore',
         'admin.users.force-delete',
+        'admin.users.impersonate',
     ],
 
     RolesEnum::EDITOR->value => [


### PR DESCRIPTION
This pull request introduces user impersonation functionality to the application, allowing certain users to impersonate others through the admin panel. The implementation includes UI changes, permission checks, and the integration of a third-party package to support this feature.

**User Impersonation Feature:**

* Added the `stechstudio/filament-impersonate` package to `composer.json` to provide impersonation capabilities.
* Updated the `EditUser` page to include an "Impersonate User" action in the header actions, grouped under an "Actions" button, using the new package.

**Permissions and Role Management:**

* Added the `admin.users.impersonate` permission to the `config/roles_permissions.php` configuration.
* Implemented `canImpersonate` and `canBeImpersonated` methods in the `User` model to restrict impersonation so that only users with the `SUPER_ADMIN` role or the `admin.users.impersonate` permission can impersonate, and to prevent `SUPER_ADMIN` users from being impersonated.

Jira:
https://moderntribe.atlassian.net/browse/BISON-19